### PR TITLE
Hotfix/error with unresolved path

### DIFF
--- a/lib/vagrant-notify-forwarder/action/start_client_forwarder.rb
+++ b/lib/vagrant-notify-forwarder/action/start_client_forwarder.rb
@@ -39,7 +39,9 @@ module VagrantPlugins
           port = env[:machine].config.notify_forwarder.port
 
           env[:machine].communicate.upload(path, "/tmp/notify-forwarder")
+          env[:ui].output("Starting notify-forwarder ...")
           env[:machine].communicate.execute("nohup /tmp/notify-forwarder receive -p #{port} &")
+          env[:ui].detail("Notify-forwarder: guest listening for file change notifications on 0.0.0.0:#{port}.")
         end
       end
     end

--- a/lib/vagrant-notify-forwarder/action/start_host_forwarder.rb
+++ b/lib/vagrant-notify-forwarder/action/start_host_forwarder.rb
@@ -44,7 +44,7 @@ module VagrantPlugins
 
             env[:machine].config.vm.synced_folders.each do |id, options|
               unless options[:disabled]
-                hostpath = File.absolute_path(options[:hostpath])
+                hostpath = options[:hostpath]
                 guestpath = options[:guestpath]
 
                 args = "watch -c 127.0.0.1:#{port} #{hostpath} #{guestpath}"

--- a/lib/vagrant-notify-forwarder/action/start_host_forwarder.rb
+++ b/lib/vagrant-notify-forwarder/action/start_host_forwarder.rb
@@ -49,6 +49,8 @@ module VagrantPlugins
 
                 args = "watch -c 127.0.0.1:#{port} #{hostpath} #{guestpath}"
                 start_watcher env, "#{path} #{args}"
+                env[:ui].detail("Notify-forwarder: host sending file change notifications to 127.0.0.1:#{port}")
+                env[:ui].detail("Notify-forwarder: host forwarding notifications on #{hostpath} to #{guestpath}")
               end
             end
           end


### PR DESCRIPTION
Fixes https://github.com/mhallin/vagrant-notify-forwarder/issues/6.

When a legal source path in the Vagrantfile for synced directories contains tilde expansion (~/) shorthand for the current user's directory, notify-forwarder on the host fails with the following error:

libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: Could not resolve path

This is because File.absolute_path() treats the tilde as a relative path to the current working directory, not the user's directory.  The current version of notify-forwarder seems to be able to deal with tilde expansion natively, so we can pass the :host path values directly to notify-forwarder.

Additionally, some extra output was added during notify-forwarder loading.
