### PR TITLE
Fix suspend and resume issue

### DIFF
--- a/lib/vagrant-notify-forwarder/action/check_boot_state.rb
+++ b/lib/vagrant-notify-forwarder/action/check_boot_state.rb
@@ -1,0 +1,18 @@
+module VagrantPlugins
+  module VagrantNotifyForwarder
+    module Action
+      class CheckBootState
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          return unless env[:machine].config.notify_forwarder.enable
+          $BOOT_SAVED = env[:machine].state.id == :saved
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-notify-forwarder/action/start_client_forwarder.rb
+++ b/lib/vagrant-notify-forwarder/action/start_client_forwarder.rb
@@ -31,6 +31,8 @@ module VagrantPlugins
         def call(env)
           @app.call env
 
+          return if $BOOT_SAVED
+
           return unless env[:machine].config.notify_forwarder.enable
 
           path = ensure_binary_downloaded env


### PR DESCRIPTION
Do not recreate `notify-forwarder` process on guest when resuming and kill `notify-forwarder` process on host when suspending.
