### PR TITLE
Updated readme, added opt out

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,15 @@ machine, add the following line to your `Vagrantfile`:
 config.notify_forwarder.enable = false
 ```
 
+To disable this plugin on a per synced folder basis, you can use the option `disable_notify_forwarder`:
+
+```ruby
+config.vm.synced_folder "~/Projects", "/home/vagrant/Projects", disable_notify_forwarder: true
+```
+
 ## Contributors
 
 * [CharlieC3](https://github.com/CharlieC3)
 * [hedinfaok](https://github.com/hedinfaok)
 * [seff](https://github.com/seff)
+* [Josh O'Neal](https://github.com/LifeCoder45)

--- a/lib/vagrant-notify-forwarder/action/start_host_forwarder.rb
+++ b/lib/vagrant-notify-forwarder/action/start_host_forwarder.rb
@@ -43,7 +43,9 @@ module VagrantPlugins
             return unless path
 
             env[:machine].config.vm.synced_folders.each do |id, options|
-              unless options[:disabled]
+              # check to see if this plugin is globally disabled, 
+              # or disabled for this specific directory
+              unless options[:disabled] || options[:disable_notify_forwarder]
                 hostpath = File.expand_path(options[:hostpath], env[:root_path])
                 guestpath = options[:guestpath]
 


### PR DESCRIPTION
This PR adds a new option on a per synced folder basis, `disable_notify_forwarder`, allowing a user to enable vagrant-notify-forwarder overall, but exclude some directories.

We have used VNF to enable Node hot reload, but now it's causing issues with our Django backend, when using PyCharm. Constant complaints about keeping in memory or on disc files.

Since Runserver seems to reload just fine without the forwarder, opting out just that directory seems like a quick fix.